### PR TITLE
Allow ‘none’ as acceptable placement align

### DIFF
--- a/bootstrap-growl.js
+++ b/bootstrap-growl.js
@@ -173,6 +173,8 @@
 			case 'right':
 				$template.css('right', settings.offset.x + 'px');
 				break;
+			case 'none':
+				break;
 		}
 		$template.addClass('growl-animated');
 


### PR DESCRIPTION
Some users may want to apply their own css styles to the growl notification for placement