### PR TITLE
Adjust position of successor after animation finished

### DIFF
--- a/bootstrap-growl.js
+++ b/bootstrap-growl.js
@@ -265,16 +265,20 @@
 
 			base.addClass(this.settings.animate.exit);
 
-			base.nextAll('[data-growl-position="' + this.settings.placement.from + '-' + this.settings.placement.align + '"]').each(function() {
-				$(this).css(settings.placement.from, posX);
-				posX = (parseInt(posX)+(settings.spacing)) + $(this).outerHeight();
-			});
+			var successors = base.nextAll('[data-growl-position="' + this.settings.placement.from + '-' + this.settings.placement.align + '"]');
+			var adjustSuccessorPositions = function() {
+				successors.each(function() {
+					$(this).css(settings.placement.from, posX);
+					posX = (parseInt(posX)+(settings.spacing)) + $(this).outerHeight();
+				});
+			}
 
 			base.one('webkitAnimationStart oanimationstart MSAnimationStart animationstart', function(event) {
 				hasAnimation = true;
 			});
 
 			base.one('webkitAnimationEnd oanimationend MSAnimationEnd animationend', function(event) {
+				adjustSuccessorPositions();
 				$(this).remove();
 				if (settings.onHidden) {
 					settings.onHidden(event);
@@ -283,6 +287,7 @@
 
 			setTimeout(function() {
 				if (!hasAnimation) {
+					adjustSuccessorPositions();
 					base.remove();
 					if (settings.onHidden) {
 						settings.onHidden(event);
@@ -290,7 +295,7 @@
 				}
 			}, 100);
 
- 			return this;
+			return this;
 		}
 	};
 


### PR DESCRIPTION
When closing a growl, adjust the position of the successors only after the animation has finished (if there is an animation taking place).

Also very minor whitespace cleanup.