### PR TITLE
Wrong positioning when closing one notification and adding new one simultaneously

### DIFF
--- a/bootstrap-notify.js
+++ b/bootstrap-notify.js
@@ -327,7 +327,7 @@
 				posX = parseInt(this.$ele.css(this.settings.placement.from)),
 				hasAnimation = false;
 
-			this.$ele.data('closing', 'true').addClass(this.settings.animate.exit);
+			this.$ele.attr('data-closing', 'true').addClass(this.settings.animate.exit);
 			self.reposition(posX);
 
 			if ($.isFunction(self.settings.onClose)) {


### PR DESCRIPTION
I've had issues with wrong positioning of notifications when closing one notification and adding new one simultaneously. I've been able to track this problem down to the close method which was not adding `data-closing` attribute and therefore the positioning of new notification was wrong - it was above the old one (which was already closing) and after the old one was closed, it left a a blank space. Using `attr()` method instead of `data()` solved the problem (i.e. `data-closing` attribute is generated as expected).