### PR TITLE
Allows binding to 'click' event of notify box

### DIFF
--- a/bootstrap-notify.js
+++ b/bootstrap-notify.js
@@ -48,6 +48,7 @@
 		onShown: null,
 		onClose: null,
 		onClosed: null,
+        onClick: null,
 		icon_type: 'class',
 		template: '<div data-notify="container" class="col-xs-11 col-sm-4 alert alert-{0}" role="alert"><button type="button" aria-hidden="true" class="close" data-notify="dismiss">&times;</button><span data-notify="icon"></span> <span data-notify="title">{1}</span> <span data-notify="message">{2}</span><div class="progress" data-notify="progressbar"><div class="progress-bar progress-bar-{0}" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;"></div></div><a href="{3}" target="{4}" data-notify="url"></a></div>'
 	};
@@ -298,6 +299,14 @@
 			this.$ele.find('[data-notify="dismiss"]').on('click', function () {
 				self.close();
 			});
+
+			if ($.isFunction(self.settings.onClick)) {
+			    this.$ele.on('click', function (event) {
+			        if (event.target != self.$ele.find('[data-notify="dismiss"]')[0]) {
+			            self.settings.onClick.call(this, event);
+			        }
+			    });
+			}
 
 			this.$ele.mouseover(function () {
 				$(this).data('data-hover', "true");


### PR DESCRIPTION
This small change allows the client to bind to the `click` event of the popup, rather than needing to specify a URL.