### PR TITLE
Fixes bug when updating icons multiple times

### DIFF
--- a/bootstrap-notify.js
+++ b/bootstrap-notify.js
@@ -163,6 +163,7 @@
 									}
 									$icon.attr('src', commands[cmd]);
 								}
+								self.settings.content.icon = commands[command];
 								break;
 							case "progress":
 								var newDelay = self.settings.delay - (self.settings.delay * (commands[cmd] / 100));


### PR DESCRIPTION
The settings for icon were not being updated when update was called. This meant multiple calls to update icon would not work.