### PR TITLE
Add support for $.notify('message', { ... }) usage in typings.

### DIFF
--- a/typings/bootstrap-notify/notify.d.ts
+++ b/typings/bootstrap-notify/notify.d.ts
@@ -5,7 +5,7 @@
 interface JQueryStatic {
 	/* tslint:enable: interface-name */
 	notify(message: string): INotifyReturn;
-	notify(opts: INotifyOptions, settings?: INotifySettings): INotifyReturn;
+	notify(opts: INotifyOptions|string, settings?: INotifySettings): INotifyReturn;
 	notifyDefaults(settings: INotifySettings): void;
 	notifyClose(): void;
 	notifyClose(command: string): void;
@@ -57,7 +57,7 @@ interface UpdateCommands {
 	icon?: string;
 }
 
-interface NotifyReturn {
+interface INotifyReturn {
 	$ele: JQueryStatic;
 	close(): void;
 	update(commands: UpdateCommands|Record<string, any>): void;


### PR DESCRIPTION
Enables `$.notify('message', { settings })` usage. Currently supports only message only or `$.notify({ options }, { settings })`