### PR TITLE
Add new 'data-notify="icon"' option 

### DIFF
--- a/bootstrap-notify.js
+++ b/bootstrap-notify.js
@@ -206,6 +206,8 @@
 		setIcon: function () {
 			if (this.settings.icon_type.toLowerCase() === 'class') {
 				this.$ele.find('[data-notify="icon"]').addClass(this.settings.content.icon);
+			}else if (this.settings.icon_type.toLowerCase() === 'content') {
+				this.$ele.find('[data-notify="icon"]').text(this.settings.content.icon);
 			} else {
 				if (this.$ele.find('[data-notify="icon"]').is('img')) {
 					this.$ele.find('[data-notify="icon"]').attr('src', this.settings.content.icon);


### PR DESCRIPTION
Add new 'data-notify="icon"' option  'Content' to replace inside content on element marked with 'data-notify' attr

Used for  Material icons or similar libraries

[Link reference](https://github.com/mouse0270/bootstrap-notify/issues/207#issue-371190643)